### PR TITLE
Add SQL fix for Supabase RLS recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# TimerGateBall Web
+
+This project uses Supabase as its backend. If you encounter `infinite recursion detected in policy` errors when fetching data from `team_members` or `teams`, apply the SQL in `docs/supabase-policies.sql` to reset the RLS policies.
+
+```bash
+supabase db query < docs/supabase-policies.sql
+```
+
+This defines a `public.is_member` function and policies that avoid self-referential checks.

--- a/docs/supabase-policies.sql
+++ b/docs/supabase-policies.sql
@@ -1,0 +1,36 @@
+-- SQL setup for Supabase RLS
+-- function to check membership without recursion
+CREATE OR REPLACE FUNCTION public.is_member(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.team_members tm
+    WHERE tm.team_id = p_team_id
+      AND tm.user_id = auth.uid()
+  );
+$$;
+
+-- policy using the function
+DROP POLICY IF EXISTS "Team members can read" ON team_members;
+CREATE POLICY "Team members can read"
+  ON team_members
+  FOR SELECT
+  USING (public.is_member(team_id));
+
+-- ensure the same check for teams table
+DROP POLICY IF EXISTS "Team members can select" ON teams;
+CREATE POLICY "Team members can select"
+  ON teams
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.team_members tm
+      WHERE tm.team_id = id
+        AND tm.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- document how to apply Supabase policy fix
- include SQL script with the `is_member` function and updated policies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bdf6075548328ad55df1b8b8a48eb

## Resumo por Sourcery

Adiciona um script SQL para corrigir a recursão RLS do Supabase, criando uma função auxiliar `is_member` e atualizando as políticas de segurança em nível de linha em `team_members` e `teams`, e documenta sua aplicação no README.

Melhorias:
- Introduz a função SQL `public.is_member` para verificar a associação à equipe sem recursão auto-referencial
- Substitui as políticas RLS existentes em `team_members` e `teams` para usar verificações de associação não recursivas

Documentação:
- Adiciona `docs/supabase-policies.sql` com a nova função e políticas atualizadas
- Atualiza o README para instruir a execução do script SQL para resolver erros de recursão infinita

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a SQL script to fix Supabase RLS recursion by creating an `is_member` helper function and updating row-level security policies on `team_members` and `teams`, and document its application in the README.

Enhancements:
- Introduce `public.is_member` SQL function to check team membership without self-referential recursion
- Replace existing RLS policies on `team_members` and `teams` to use non-recursive membership checks

Documentation:
- Add `docs/supabase-policies.sql` with the new function and updated policies
- Update README to instruct running the SQL script to resolve infinite recursion errors

</details>