### PR TITLE
Fix auth context and add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+.gitignore
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
-
+.env
+.DS_Store
+public/llms.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# production stage
+FROM node:18-alpine AS prod
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,39 @@ supabase db query < docs/supabase-policies.sql
 ```
 
 This defines a `public.is_member` function and policies that avoid self-referential checks.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available on `http://localhost:5173`.
+
+## Production Build
+
+Create an optimized build and preview it locally:
+
+```bash
+npm run build
+npm run preview
+```
+
+## Docker Usage
+
+The repository contains a `Dockerfile` that builds the production assets and serves them using [serve](https://www.npmjs.com/package/serve).
+
+Build the image and run a container:
+
+```bash
+docker build -t timergateball-web .
+docker run -p 4173:4173 timergateball-web
+```
+
+## Environment
+
+The Supabase keys are currently hard coded in `src/lib/customSupabaseClient.js`. For production deployments you should replace these values with environment variables and avoid committing secrets to version control.

--- a/src/contexts/SupabaseAuthContext.jsx
+++ b/src/contexts/SupabaseAuthContext.jsx
@@ -83,6 +83,26 @@ export const AuthProvider = ({ children }) => {
     return { error };
   }, [toast]);
 
+  const sendPasswordReset = useCallback(async (email) => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth?view=update_password`,
+    });
+
+    if (error) {
+      toast({
+        variant: "destructive",
+        title: "Erro ao enviar e-mail",
+        description: error.message,
+      });
+    } else {
+      toast({
+        title: "E-mail de recuperação enviado",
+        description: "Verifique sua caixa de entrada para redefinir sua senha.",
+      });
+    }
+    return { error };
+  }, [toast]);
+
   const value = useMemo(() => ({
     user,
     session,
@@ -90,7 +110,8 @@ export const AuthProvider = ({ children }) => {
     signUp,
     signIn,
     signOut,
-  }), [user, session, loading, signUp, signIn, signOut]);
+    sendPasswordReset,
+  }), [user, session, loading, signUp, signIn, signOut, sendPasswordReset]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };


### PR DESCRIPTION
## Summary
- fix missing `sendPasswordReset` in SupabaseAuthContext
- extend `.gitignore`
- add `.dockerignore` and `Dockerfile`
- update README with usage instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c51d316e8832890485952e3d56136