### PR TITLE
Enable scroll on lobby and team screens

### DIFF
--- a/src/components/ManageTeamsDialog.jsx
+++ b/src/components/ManageTeamsDialog.jsx
@@ -55,14 +55,14 @@ const ManageTeamsDialog = ({ open, onOpenChange }) => {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px] bg-gray-800 border-gray-700 text-white">
+      <DialogContent className="sm:max-w-[425px] max-h-[80vh] overflow-y-auto bg-gray-800 border-gray-700 text-white">
         <DialogHeader>
           <DialogTitle>Gerenciar Equipes</DialogTitle>
           <DialogDescription className="text-gray-400">
             Selecione uma equipe que você capitaneia para gerenciar.
           </DialogDescription>
         </DialogHeader>
-        <div className="py-4">
+        <div className="py-4 max-h-[60vh] overflow-y-auto">
           {loading ? (
             <p>Carregando suas equipes...</p>
           ) : teams.length === 0 ? (

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -59,7 +59,7 @@ const LobbyScreen = () => {
   }, [fetchGames]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col items-center p-4 text-white">
+    <div className="min-h-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col items-center p-4 text-white">
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/src/screens/ManageTeamScreen.jsx
+++ b/src/screens/ManageTeamScreen.jsx
@@ -232,7 +232,7 @@ const ManageTeamScreen = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-black p-4 md:p-8 text-white">
+    <div className="min-h-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black p-4 md:p-8 text-white">
       <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="max-w-4xl mx-auto">
         <Button onClick={() => navigate('/')} variant="ghost" className="mb-6">
           <ArrowLeft className="mr-2 h-4 w-4" /> Voltar ao Lobby


### PR DESCRIPTION
## Summary
- allow vertical scrolling on the lobby screen
- allow vertical scrolling on the manage team screen
- enable scrollable dialog for selecting teams

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c5537d39883288d133140034d515b

## Resumo por Sourcery

Permitir a rolagem vertical nos ecrãs do lobby e de gestão de equipas e tornar a caixa de diálogo de seleção de equipas rolável.

Melhorias:
- Adicionar `overflow-y-auto` aos contentores principais de `LobbyScreen` e `ManageTeamScreen` para suportar a rolagem vertical.
- Adicionar restrições de `max-height` e `overflow-y-auto` ao conteúdo de `ManageTeamsDialog` e à lista de equipas para permitir a rolagem.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable vertical scrolling on the lobby and manage team screens and make the team selection dialog scrollable.

Enhancements:
- Add overflow-y-auto to main containers of LobbyScreen and ManageTeamScreen to support vertical scrolling.
- Add max-height constraints and overflow-y-auto to ManageTeamsDialog content and team list for scrollability.

</details>