### PR TITLE
Add footer with policy links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,8 +7,11 @@ import GameScreen from '@/components/GameScreen.jsx';
 import AuthScreen from '@/screens/AuthScreen';
 import LobbyScreen from '@/screens/LobbyScreen';
 import ManageTeamScreen from '@/screens/ManageTeamScreen';
+import PrivacyPolicy from '@/pages/PrivacyPolicy.jsx';
+import TermsOfService from '@/pages/TermsOfService.jsx';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import { GameProvider } from '@/contexts/GameContext.jsx';
+import Footer from '@/components/Footer.jsx';
 
 function App() {
   const { session, loading } = useAuth();
@@ -31,33 +34,36 @@ function App() {
         <GameProvider>
           <Routes>
             <Route path="/auth" element={!session ? <AuthScreen /> : <Navigate to="/" />} />
-            <Route 
-              path="/game/:gameId" 
+            <Route
+              path="/game/:gameId"
               element={
                 <ProtectedRoute>
                   <GameScreen />
                 </ProtectedRoute>
-              } 
+              }
             />
-             <Route 
-              path="/team/:teamId" 
+             <Route
+              path="/team/:teamId"
               element={
                 <ProtectedRoute>
                   <ManageTeamScreen />
                 </ProtectedRoute>
-              } 
+              }
             />
-            <Route 
-              path="/" 
+            <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+            <Route path="/terms-of-service" element={<TermsOfService />} />
+            <Route
+              path="/"
               element={
                 <ProtectedRoute>
                   <LobbyScreen />
                 </ProtectedRoute>
-              } 
+              }
             />
             <Route path="*" element={<Navigate to={session ? "/" : "/auth"} />} />
           </Routes>
         </GameProvider>
+        <Footer />
       </Router>
     </>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function Footer() {
+  return (
+    <footer className="text-center text-gray-400 text-sm py-6">
+      <div>
+        <Link to="/privacy-policy" className="hover:underline">Política de Privacidade</Link>
+        <span className="mx-1">|</span>
+        <Link to="/terms-of-service" className="hover:underline">Termos de Uso</Link>
+      </div>
+      <div className="mt-2">
+        © 2025 YD Software. Todos os direitos reservados. Sistema 100% local e seguro.
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -11,6 +11,7 @@ import { useGameState } from '@/hooks/useGameState';
 import { useAudioManager } from '@/hooks/useAudioManager';
 import { useGame } from '@/contexts/GameContext.jsx';
 import { useWakeLock } from '@/hooks/useWakeLock';
+import Footer from '@/components/Footer.jsx';
 
 const GameScreen = () => {
   const { gameId } = useParams();
@@ -101,6 +102,7 @@ const GameScreen = () => {
   }
 
   return (
+    <>
     <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-4 gap-4">
       <div className="flex gap-4 h-20">
         <TeamScore team="red" score={teamScores.red} label="EQUIPE VERMELHA" />
@@ -149,6 +151,8 @@ const GameScreen = () => {
         cancelText="Cancelar"
       />
     </div>
+    <Footer />
+    </>
   );
 };
 

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import Footer from '@/components/Footer.jsx';
 
 function PrivacyPolicy() {
   const navigate = useNavigate();
   return (
-    <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
+    <>
+      <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
       <Helmet>
         <title>Política de Privacidade</title>
         <meta name="description" content="Saiba como tratamos seus dados no gerador de currículos." />
@@ -22,7 +24,9 @@ function PrivacyPolicy() {
       <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
         Voltar para a página inicial
       </Button>
-    </div>
+      </div>
+      <Footer />
+    </>
   );
 }
 

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import Footer from '@/components/Footer.jsx';
 
 function TermsOfService() {
   const navigate = useNavigate();
   return (
-    <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
+    <>
+      <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
       <Helmet>
         <title>Termos de Uso</title>
         <meta name="description" content="Conheça os termos de uso do gerador de currículos." />
@@ -22,7 +24,9 @@ function TermsOfService() {
       <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
         Voltar para a página inicial
       </Button>
-    </div>
+      </div>
+      <Footer />
+    </>
   );
 }
 

--- a/src/screens/AuthScreen.jsx
+++ b/src/screens/AuthScreen.jsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { motion } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
+import Footer from '@/components/Footer.jsx';
 
 const AuthScreen = () => {
   const [authMode, setAuthMode] = useState('login'); // 'login', 'signup', 'recovery'
@@ -48,6 +49,7 @@ const AuthScreen = () => {
   };
 
   return (
+    <>
     <div className="min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-black flex items-center justify-center p-4">
       <motion.div
         initial={{ opacity: 0, y: -20 }}
@@ -109,6 +111,8 @@ const AuthScreen = () => {
         </div>
       </motion.div>
     </div>
+    <Footer />
+  </>
   );
 };
 

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { Users, LogOut } from 'lucide-react';
 import CreateGameDialog from '@/components/CreateGameDialog';
 import ManageTeamsDialog from '@/components/ManageTeamsDialog';
+import Footer from '@/components/Footer.jsx';
 
 const LobbyScreen = () => {
   const { user, signOut } = useAuth();
@@ -59,6 +60,7 @@ const LobbyScreen = () => {
   }, [fetchGames]);
 
   return (
+    <>
     <div className="min-h-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col items-center p-4 text-white">
       <motion.div
         initial={{ opacity: 0, y: -20 }}
@@ -121,6 +123,8 @@ const LobbyScreen = () => {
       </motion.div>
       <ManageTeamsDialog open={isManageTeamsDialogOpen} onOpenChange={setManageTeamsDialogOpen} />
     </div>
+    <Footer />
+    </>
   );
 };
 

--- a/src/screens/ManageTeamScreen.jsx
+++ b/src/screens/ManageTeamScreen.jsx
@@ -21,6 +21,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { motion } from 'framer-motion';
 import { ArrowLeft, UserPlus, Trash2, Crown, ChevronsUpDown } from 'lucide-react';
+import Footer from '@/components/Footer.jsx';
 
 const UserCombobox = ({ onSelectUser, disabled }) => {
   const [open, setOpen] = useState(false);
@@ -46,7 +47,7 @@ const UserCombobox = ({ onSelectUser, disabled }) => {
     };
     
     const debounce = setTimeout(() => {
-        fetchUsers();
+      fetchUsers();
     }, 300);
 
     return () => clearTimeout(debounce);
@@ -218,20 +219,29 @@ const ManageTeamScreen = () => {
   };
 
   if (loading) {
-    return <div className="h-screen w-screen bg-gray-900 flex items-center justify-center text-white">Carregando equipe...</div>;
+    return (
+      <>
+        <div className="h-screen w-screen bg-gray-900 flex items-center justify-center text-white">Carregando equipe...</div>
+        <Footer />
+      </>
+    );
   }
 
   if (!isCaptain) {
     return (
-       <div className="h-screen w-screen bg-gray-900 flex flex-col items-center justify-center text-white p-4">
+      <>
+        <div className="h-screen w-screen bg-gray-900 flex flex-col items-center justify-center text-white p-4">
         <h1 className="text-2xl font-bold text-red-500 mb-4">Acesso Negado</h1>
         <p className="text-gray-400 mb-8">Você não tem permissão para gerenciar esta equipe.</p>
         <Button onClick={() => navigate('/')}><ArrowLeft className="mr-2 h-4 w-4" /> Voltar ao Lobby</Button>
       </div>
-    )
+        <Footer />
+      </>
+    );
   }
 
   return (
+    <>
     <div className="min-h-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black p-4 md:p-8 text-white">
       <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="max-w-4xl mx-auto">
         <Button onClick={() => navigate('/')} variant="ghost" className="mb-6">
@@ -291,6 +301,8 @@ const ManageTeamScreen = () => {
         </div>
       </motion.div>
     </div>
+    <Footer />
+  </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `Footer` component
- show footer on all screens and pages
- add Privacy Policy and Terms of Service routes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c59ed92d0832893adb085c92149c1

## Resumo por Sourcery

Adiciona um rodapé para todo o site com links para as políticas e implementa páginas e rotas separadas para a Política de Privacidade e os Termos de Serviço

Novas funcionalidades:
- Introduz um componente de Rodapé persistente com links para a Política de Privacidade e os Termos de Serviço
- Adiciona páginas de Política de Privacidade e Termos de Serviço juntamente com suas rotas

Melhorias:
- Renderiza o componente de Rodapé em todas as telas do aplicativo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a site-wide footer featuring policy links and implement separate pages and routes for Privacy Policy and Terms of Service

New Features:
- Introduce a persistent Footer component with links to Privacy Policy and Terms of Service
- Add Privacy Policy and Terms of Service pages along with their routes

Enhancements:
- Render the Footer component on all application screens

</details>