### PR TITLE
Adjust scoring sequence

### DIFF
--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -100,9 +100,12 @@ export const useGameState = (gameId) => {
   
   const updatePlayerScore = useCallback((playerId) => {
     if (!gameState || !isCaptain) return;
+    const scoreSequence = [0, 1, 2, 3, 5];
     const currentScore = gameState.scores[playerId];
-    const newScore = currentScore >= 8 ? 0 : currentScore + 1;
-    
+    const currentIndex = scoreSequence.indexOf(currentScore);
+    const nextIndex = currentIndex === -1 ? 1 : (currentIndex + 1) % scoreSequence.length;
+    const newScore = scoreSequence[nextIndex];
+
     const newScores = { ...gameState.scores, [playerId]: newScore };
     const newState = { ...gameState, scores: newScores };
     updateRemoteState(newState);


### PR DESCRIPTION
## Summary
- update the player score increment logic to cycle through 0,1,2,3,5

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c624b85bc8328ae86cf96cb890f7f

## Resumo por Sourcery

Melhorias:
- Percorre os scores do jogador através da sequência [0, 1, 2, 3, 5] a cada atualização.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Cycle player scores through the sequence [0, 1, 2, 3, 5] on each update.

</details>