### PR TITLE
Fix duplicate footer

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -11,7 +11,6 @@ import { useGameState } from '@/hooks/useGameState';
 import { useAudioManager } from '@/hooks/useAudioManager';
 import { useGame } from '@/contexts/GameContext.jsx';
 import { useWakeLock } from '@/hooks/useWakeLock';
-import Footer from '@/components/Footer.jsx';
 
 const GameScreen = () => {
   const { gameId } = useParams();
@@ -151,7 +150,6 @@ const GameScreen = () => {
         cancelText="Cancelar"
       />
     </div>
-    <Footer />
     </>
   );
 };

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import Footer from '@/components/Footer.jsx';
 
 function PrivacyPolicy() {
   const navigate = useNavigate();
@@ -24,10 +23,9 @@ function PrivacyPolicy() {
       <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
         Voltar para a página inicial
       </Button>
-      </div>
-      <Footer />
-    </>
-  );
-}
+        </div>
+      </>
+    );
+  }
 
 export default PrivacyPolicy;

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import Footer from '@/components/Footer.jsx';
 
 function TermsOfService() {
   const navigate = useNavigate();
@@ -24,10 +23,9 @@ function TermsOfService() {
       <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
         Voltar para a página inicial
       </Button>
-      </div>
-      <Footer />
-    </>
-  );
-}
+        </div>
+      </>
+    );
+  }
 
 export default TermsOfService;

--- a/src/screens/AccountScreen.jsx
+++ b/src/screens/AccountScreen.jsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { motion } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
-import Footer from '@/components/Footer.jsx';
 
 const AccountScreen = () => {
   const { user } = useAuth();
@@ -98,10 +97,9 @@ const AccountScreen = () => {
             </Button>
           </form>
         </motion.div>
-      </div>
-      <Footer />
-    </>
-  );
-};
+        </div>
+      </>
+    );
+  };
 
 export default AccountScreen;

--- a/src/screens/AuthScreen.jsx
+++ b/src/screens/AuthScreen.jsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { motion } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
-import Footer from '@/components/Footer.jsx';
 
 const AuthScreen = () => {
   const [authMode, setAuthMode] = useState('login'); // 'login', 'signup', 'recovery'
@@ -110,9 +109,8 @@ const AuthScreen = () => {
           )}
         </div>
       </motion.div>
-    </div>
-    <Footer />
-  </>
+      </div>
+    </>
   );
 };
 

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/SupabaseAuthContext.jsx';
 import { Button } from '@/components/ui/button';
@@ -10,7 +9,6 @@ import { Users, LogOut, Trash2, Settings } from 'lucide-react';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import CreateGameDialog from '@/components/CreateGameDialog';
 import ManageTeamsDialog from '@/components/ManageTeamsDialog';
-import Footer from '@/components/Footer.jsx';
 
 const LobbyScreen = () => {
   const { user, signOut } = useAuth();
@@ -201,9 +199,8 @@ const LobbyScreen = () => {
         cancelText="Cancelar"
       />
     </div>
-    <Footer />
-    </>
-  );
-};
+      </>
+    );
+  };
 
 export default LobbyScreen;

--- a/src/screens/ManageTeamScreen.jsx
+++ b/src/screens/ManageTeamScreen.jsx
@@ -21,7 +21,6 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { motion } from 'framer-motion';
 import { ArrowLeft, UserPlus, Trash2, Crown, ChevronsUpDown } from 'lucide-react';
-import Footer from '@/components/Footer.jsx';
 
 const UserCombobox = ({ onSelectUser, disabled }) => {
   const [open, setOpen] = useState(false);
@@ -222,10 +221,9 @@ const ManageTeamScreen = () => {
     return (
       <>
         <div className="h-screen w-screen bg-gray-900 flex items-center justify-center text-white">Carregando equipe...</div>
-        <Footer />
-      </>
-    );
-  }
+        </>
+      );
+    }
 
   if (!isCaptain) {
     return (
@@ -235,10 +233,9 @@ const ManageTeamScreen = () => {
         <p className="text-gray-400 mb-8">Você não tem permissão para gerenciar esta equipe.</p>
         <Button onClick={() => navigate('/')}><ArrowLeft className="mr-2 h-4 w-4" /> Voltar ao Lobby</Button>
       </div>
-        <Footer />
-      </>
-    );
-  }
+        </>
+      );
+    }
 
   return (
     <>
@@ -301,9 +298,8 @@ const ManageTeamScreen = () => {
         </div>
       </motion.div>
     </div>
-    <Footer />
-  </>
-  );
-};
+    </>
+    );
+  };
 
 export default ManageTeamScreen;


### PR DESCRIPTION
## Summary
- show footer only once by removing page-level footers
- update imports accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d1c5d3d708328abb641c23d415d38

## Resumo por Sourcery

Remova rodapés duplicados, eliminando as importações e o uso de `Footer` no nível da página em várias telas e páginas.

Correções de bugs:
- Elimine a exibição de rodapé duplicado removendo as importações do componente `Footer` e as chamadas de renderização de componentes de página e tela individuais.

Melhorias:
- Limpe as importações `Footer` não utilizadas nos componentes afetados.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove duplicate footers by eliminating page-level Footer imports and usage across multiple screens and pages

Bug Fixes:
- Eliminate duplicate footer display by removing Footer component imports and render calls from individual page and screen components

Enhancements:
- Clean up unused Footer imports in affected components

</details>