### PR TITLE
Shrink icons in game screens

### DIFF
--- a/src/components/CreateGameDialog.jsx
+++ b/src/components/CreateGameDialog.jsx
@@ -98,7 +98,7 @@ const CreateGameDialog = () => {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button className="w-full h-28 text-lg bg-yellow-500 hover:bg-yellow-600 text-black font-bold flex flex-col gap-1">
-          <PlusCircle size={28} />
+          <PlusCircle size={24} />
           Criar Novo Jogo
         </Button>
       </DialogTrigger>

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -138,10 +138,10 @@ const GameScreen = () => {
       {isCaptain && (
         <div className="flex justify-center gap-2 sm:gap-4 h-10 sm:h-12">
           <Button variant="outline" size="sm" onClick={handleTimerClick} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">
-            {status === 'running' ? <><Pause className="w-4 h-4 mr-2" /> Pausar</> : <><Play className="w-4 h-4 mr-2" /> Iniciar</>}
+            {status === 'running' ? <><Pause className="w-3 h-3 mr-2" /> Pausar</> : <><Play className="w-3 h-3 mr-2" /> Iniciar</>}
           </Button>
           <Button variant="outline" size="sm" onClick={() => setShowConfirmDialog(true)} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">
-            <RotateCcw className="w-4 h-4 mr-2" /> Reiniciar
+            <RotateCcw className="w-3 h-3 mr-2" /> Reiniciar
           </Button>
         </div>
       )}

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -92,10 +92,10 @@ const LobbyScreen = () => {
           </h1>
           <div className="flex gap-2 flex-shrink-0">
             <Button onClick={() => navigate('/account')} variant="ghost" className="text-gray-300 hover:text-white">
-              <Settings className="mr-2 h-4 w-4" /> Conta
+              <Settings className="mr-2 h-3 w-3" /> Conta
             </Button>
             <Button onClick={signOut} variant="ghost" className="text-red-400 hover:text-red-500 hover:bg-red-900/20">
-              <LogOut className="mr-2 h-4 w-4" /> Sair
+              <LogOut className="mr-2 h-3 w-3" /> Sair
             </Button>
           </div>
         </header>
@@ -106,7 +106,7 @@ const LobbyScreen = () => {
           </motion.div>
           <motion.div whileHover={{ scale: 1.03 }}>
              <Button onClick={() => setManageTeamsDialogOpen(true)} variant="outline" className="w-full h-28 text-lg bg-transparent border-yellow-500 text-yellow-500 hover:bg-yellow-500 hover:text-black flex flex-col gap-1">
-              <Users size={28}/>
+              <Users size={24}/>
               Gerenciar Equipes
             </Button>
           </motion.div>
@@ -141,7 +141,7 @@ const LobbyScreen = () => {
                           Entrar no Jogo
                         </Button>
                         <Button variant="destructive" size="icon" onClick={() => setDeleteGameId(game.id)}>
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-3 w-3" />
                         </Button>
                       </div>
                     </motion.li>
@@ -181,7 +181,7 @@ const LobbyScreen = () => {
                           Ver Jogo
                         </Button>
                         <Button variant="destructive" size="icon" onClick={() => setDeleteGameId(game.id)}>
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-3 w-3" />
                         </Button>
                       </div>
                     </motion.li>

--- a/src/screens/ManageTeamScreen.jsx
+++ b/src/screens/ManageTeamScreen.jsx
@@ -73,7 +73,7 @@ const UserCombobox = ({ onSelectUser, disabled }) => {
           {value
             ? users.find((user) => user.id === value)?.email || 'Selecione um jogador'
             : 'Selecione um jogador...'}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0 bg-gray-800 border-gray-700 text-white">
@@ -231,7 +231,7 @@ const ManageTeamScreen = () => {
         <div className="h-screen w-screen bg-gray-900 flex flex-col items-center justify-center text-white p-4">
         <h1 className="text-2xl font-bold text-red-500 mb-4">Acesso Negado</h1>
         <p className="text-gray-400 mb-8">Você não tem permissão para gerenciar esta equipe.</p>
-        <Button onClick={() => navigate('/')}><ArrowLeft className="mr-2 h-4 w-4" /> Voltar ao Lobby</Button>
+        <Button onClick={() => navigate('/')}><ArrowLeft className="mr-2 h-3 w-3" /> Voltar ao Lobby</Button>
       </div>
         </>
       );
@@ -242,7 +242,7 @@ const ManageTeamScreen = () => {
     <div className="min-h-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black p-4 md:p-8 text-white">
       <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="max-w-4xl mx-auto">
         <Button onClick={() => navigate('/')} variant="ghost" className="mb-6">
-          <ArrowLeft className="mr-2 h-4 w-4" /> Voltar ao Lobby
+          <ArrowLeft className="mr-2 h-3 w-3" /> Voltar ao Lobby
         </Button>
 
         <h1 className="text-4xl font-bold mb-2">Gerenciar Equipe</h1>
@@ -253,7 +253,7 @@ const ManageTeamScreen = () => {
           <div className="flex flex-col sm:flex-row gap-4">
              <UserCombobox onSelectUser={setSelectedUser} disabled={false} />
             <Button onClick={handleAddMember} className="bg-yellow-500 hover:bg-yellow-600 text-black">
-              <UserPlus className="mr-2 h-4 w-4" /> Adicionar
+              <UserPlus className="mr-2 h-3 w-3" /> Adicionar
             </Button>
           </div>
         </div>
@@ -270,7 +270,7 @@ const ManageTeamScreen = () => {
                 className="flex items-center justify-between p-4 bg-gray-700/70 rounded-lg"
               >
                 <div className="flex items-center gap-3">
-                   {member.is_captain && <Crown className="h-5 w-5 text-yellow-400" />}
+                   {member.is_captain && <Crown className="h-4 w-4 text-yellow-400" />}
                   <span className="font-medium">{member.user.email}</span>
                 </div>
                 <div className="flex items-center gap-4">
@@ -289,7 +289,7 @@ const ManageTeamScreen = () => {
                     onClick={() => handleRemoveMember(member.user.id)}
                     disabled={member.user.id === user.id}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-3 w-3" />
                   </Button>
                 </div>
               </motion.li>


### PR DESCRIPTION
## Summary
- make play, pause and restart icons smaller
- scale down icons in team management view
- shrink lobby icons and user icon
- reduce create game icon size

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68725c3a88588328bc815098968b4132

## Resumo por Sourcery

Reduzir vários ícones nas telas de Gerenciar Equipe, Lobby, Jogo e Criar Jogo para uma UI mais compacta e consistente

Melhorias:
- Reduzir as dimensões dos ícones em vários componentes (chevrons, setas, gerenciamento de usuário/equipe, configurações, logout, lixeira) nas telas de Gerenciar Equipe e Lobby
- Reduzir a escala dos ícones de controle (play, pause, restart) em GameScreen
- Diminuir o tamanho do ícone de mais de criar jogo em CreateGameDialog

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Shrink various icons across Manage Team, Lobby, Game, and Create Game screens for a more compact and consistent UI

Enhancements:
- Reduce icon dimensions across multiple components (chevrons, arrows, user/team management, settings, logout, trash) in Manage Team and Lobby screens
- Scale down control icons (play, pause, restart) in GameScreen
- Lower the size of the create game plus icon in CreateGameDialog

</details>